### PR TITLE
Add git, nvim, and beets as stow packages

### DIFF
--- a/beets/.config/beets/config.yaml
+++ b/beets/.config/beets/config.yaml
@@ -1,0 +1,44 @@
+directory: ${MUSIC_DIR}
+library: ${MUSIC_DIR}/data/musiclibrary.db
+
+import:
+    copy: yes
+    move: no
+    write: yes
+    timid: yes
+    log: ${MUSIC_DIR}/data/import.log
+
+paths:
+    default: "%the{$albumartist}/$album%aunique{}/%if{$multidisc,Disc $disc/}$track - $title"
+    singleton: "Non-Album/%the{$artist}/$title"
+    comp: "Compilations/$album%aunique{}/%if{$multidisc,Disc $disc/}$track - $title"
+
+match:
+    # Files tagged by Picard will have MBIDs — beets does direct lookup,
+    # so strong matches are the norm. Thresholds loosened as a safety net
+    # for any files Picard couldn't identify.
+    strong_rec_thresh: 0.10
+    medium_rec_thresh: 0.40
+    max_rec:
+        missing_tracks: medium
+        unmatched_tracks: medium
+
+asciify_paths: no
+
+# chroma removed — Picard handles fingerprinting/identification upstream.
+# beets no longer needs to re-fingerprint on import.
+plugins: fetchart embedart scrub
+
+fetchart:
+    auto: yes
+    minwidth: 500
+    maxwidth: 1200
+    sources: filesystem coverart itunes amazon albumart
+
+embedart:
+    auto: yes
+    maxwidth: 500
+    remove_art_file: no
+
+scrub:
+    auto: yes

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,0 +1,23 @@
+[user]
+	email = evanscahill@gmail.com
+	name = evan
+
+[core]
+	pager = delta
+
+[interactive]
+	diffFilter = delta --color-only
+
+[delta]
+	navigate = true		# use n and N to move between diff sections
+	side-by-side = true
+
+	# delta detects terminal colors automatically; set one of these to disable auto-detection
+	# dark = true
+	# light = true
+
+[merge]
+	conflictstyle = diff3
+
+[diff]
+	colorMoved = default

--- a/nvim/.config/nvim/init.lua
+++ b/nvim/.config/nvim/init.lua
@@ -1,0 +1,16 @@
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not (vim.uv or vim.loop).fs_stat(lazypath) then
+  vim.fn.system({
+    "git",
+    "clone",
+    "--filter=blob:none",
+    "https://github.com/folke/lazy.nvim.git",
+    "--branch=stable",
+    lazypath
+  })
+end
+vim.opt.rtp:prepend(lazypath)
+
+require("vim-options")
+require("lazy").setup("plugins")
+

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -1,0 +1,22 @@
+{
+  "LuaSnip": { "branch": "master", "commit": "c9b9a22904c97d0eb69ccb9bab76037838326817" },
+  "catppuccin": { "branch": "main", "commit": "384f304c8b04664c9e0091fbfb3923c5f97c1bcf" },
+  "cmp-nvim-lsp": { "branch": "main", "commit": "cbc7b02bb99fae35cb42f514762b89b5126651ef" },
+  "cmp_luasnip": { "branch": "master", "commit": "98d9cb5c2c38532bd9bdb481067b20fea8f32e90" },
+  "friendly-snippets": { "branch": "main", "commit": "6cd7280adead7f586db6fccbd15d2cac7e2188b9" },
+  "lazy.nvim": { "branch": "main", "commit": "306a05526ada86a7b30af95c5cc81ffba93fef97" },
+  "lualine.nvim": { "branch": "master", "commit": "47f91c416daef12db467145e16bed5bbfe00add8" },
+  "mason-lspconfig.nvim": { "branch": "main", "commit": "a676ab7282da8d651e175118bcf54483ca11e46d" },
+  "mason.nvim": { "branch": "main", "commit": "44d1e90e1f66e077268191e3ee9d2ac97cc18e65" },
+  "neo-tree.nvim": { "branch": "v3.x", "commit": "9d6826582a3e8c84787bd7355df22a2812a1ad59" },
+  "none-ls-extras.nvim": { "branch": "main", "commit": "c6fa39ac52814182c05552cb5d3750cae23ff0f0" },
+  "none-ls.nvim": { "branch": "main", "commit": "c9317c2a8629d4e39e7cf47be74cb67f3ab37cda" },
+  "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
+  "nvim-cmp": { "branch": "main", "commit": "da88697d7f45d16852c6b2769dc52387d1ddc45f" },
+  "nvim-lspconfig": { "branch": "master", "commit": "702f69fb167e9119f14adc4dfd4fcadf4d1b07a0" },
+  "nvim-treesitter": { "branch": "master", "commit": "42fc28ba918343ebfd5565147a42a26580579482" },
+  "nvim-web-devicons": { "branch": "master", "commit": "d7462543c9e366c0d196c7f67a945eaaf5d99414" },
+  "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
+  "render-markdown.nvim": { "branch": "main", "commit": "e3c18ddd27a853f85a6f513a864cf4f2982b9f26" },
+  "telescope.nvim": { "branch": "master", "commit": "6312868392331c9c0f22725041f1ec2bef57c751" }
+}

--- a/nvim/.config/nvim/lua/plugins/catppuccin.lua
+++ b/nvim/.config/nvim/lua/plugins/catppuccin.lua
@@ -1,0 +1,8 @@
+  return { 
+    "catppuccin/nvim", 
+    name = "catppuccin", 
+    priority = 1000, 
+    config = function()
+      vim.cmd.colorscheme "catppuccin-macchiato"
+    end
+  }

--- a/nvim/.config/nvim/lua/plugins/completions.lua
+++ b/nvim/.config/nvim/lua/plugins/completions.lua
@@ -1,0 +1,44 @@
+return {
+  {
+    "hrsh7th/cmp-nvim-lsp"
+  },
+	{
+		"L3MON4D3/LuaSnip",
+		dependencies = {
+			"saadparwaiz1/cmp_luasnip",
+      "rafamadriz/friendly-snippets"
+		},
+	},
+	{
+		"hrsh7th/nvim-cmp",
+		config = function()
+			local cmp = require("cmp")
+      require("luasnip.loaders.from_vscode").lazy_load()
+
+			cmp.setup({
+				snippet = {
+					expand = function(args)
+						require("luasnip").lsp_expand(args.body)
+					end,
+				},
+				window = {
+					completion = cmp.config.window.bordered(),
+					documentation = cmp.config.window.bordered(),
+				},
+				mapping = cmp.mapping.preset.insert({
+					["<C-b>"] = cmp.mapping.scroll_docs(-4),
+					["<C-f>"] = cmp.mapping.scroll_docs(4),
+					["<C-Space>"] = cmp.mapping.complete(),
+					["<C-e>"] = cmp.mapping.abort(),
+					["<CR>"] = cmp.mapping.confirm({ select = true }),
+				}),
+				sources = cmp.config.sources({
+					{ name = "nvim_lsp" },
+					{ name = "luasnip" },
+				}, {
+					{ name = "buffer" },
+				}),
+			})
+		end,
+	},
+}

--- a/nvim/.config/nvim/lua/plugins/lsp-config.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp-config.lua
@@ -1,0 +1,41 @@
+return {
+	{
+		"williamboman/mason.nvim",
+		config = function()
+			require("mason").setup()
+		end,
+	},
+	{
+		"williamboman/mason-lspconfig.nvim",
+		config = function()
+			require("mason-lspconfig").setup({
+				ensure_installed = { "lua_ls", "ts_ls", "angularls", "omnisharp" },
+			})
+		end,
+	},
+	{
+		"neovim/nvim-lspconfig",
+		config = function()
+			local lspconfig = require("lspconfig")
+			local capabilities = require("cmp_nvim_lsp").default_capabilities()
+
+			lspconfig.lua_ls.setup({
+				capabilities = capabilities,
+			})
+			lspconfig.ts_ls.setup({
+				capabilities = capabilities,
+			})
+			lspconfig.angularls.setup({
+				capabilities = capabilities,
+			})
+			lspconfig.omnisharp.setup({
+				capabilities = capabilities,
+				cmd = { "dotnet", "/usr/bin/omnisharp/OmniSharp.dll" },
+			})
+
+			vim.keymap.set("n", "K", vim.lsp.buf.hover, {})
+			vim.keymap.set("n", "gd", vim.lsp.buf.definition, {})
+			vim.keymap.set("n", "<leader>ca", vim.lsp.buf.code_action, {})
+		end,
+	},
+}

--- a/nvim/.config/nvim/lua/plugins/lualine.lua
+++ b/nvim/.config/nvim/lua/plugins/lualine.lua
@@ -1,0 +1,10 @@
+return {
+  "nvim-lualine/lualine.nvim",
+  config = function()
+    require("lualine").setup({
+      options = {
+        theme = "dracula"
+      }
+    })
+  end
+}

--- a/nvim/.config/nvim/lua/plugins/neo-tree.lua
+++ b/nvim/.config/nvim/lua/plugins/neo-tree.lua
@@ -1,0 +1,23 @@
+return {
+  "nvim-neo-tree/neo-tree.nvim",
+  branch = "v3.x",
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+    "nvim-tree/nvim-web-devicons", 
+    "MunifTanjim/nui.nvim"
+  },
+  config = function()
+    vim.keymap.set("n", "<C-n>", ":Neotree reveal right<Enter>")
+    
+    require("neo-tree").setup({
+      filesystem = {
+        filtered_items = {
+          visible = true
+        }
+      },
+      window = {
+        position = "right"
+      }
+    })
+  end
+}

--- a/nvim/.config/nvim/lua/plugins/none-ls.lua
+++ b/nvim/.config/nvim/lua/plugins/none-ls.lua
@@ -1,0 +1,22 @@
+return {
+	"nvimtools/none-ls.nvim",
+  dependencies = {
+    "nvimtools/none-ls-extras.nvim",
+  },
+	config = function()
+		local null_ls = require("null-ls")
+		null_ls.setup({
+			sources = {
+				null_ls.builtins.formatting.stylua,
+				null_ls.builtins.formatting.csharpier,
+				null_ls.builtins.formatting.prettier,
+				null_ls.builtins.formatting.black,
+				null_ls.builtins.formatting.isort,
+				null_ls.builtins.diagnostics.editorconfig_checker,
+				require("none-ls.diagnostics.eslint_d")
+			},
+		})
+
+		vim.keymap.set("n", "<leader>gf", vim.lsp.buf.format, {})
+	end,
+}

--- a/nvim/.config/nvim/lua/plugins/render-markdown.lua
+++ b/nvim/.config/nvim/lua/plugins/render-markdown.lua
@@ -1,0 +1,5 @@
+return {
+  "MeanderingProgrammer/render-markdown.nvim",
+  dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" },
+  opts = {},
+}

--- a/nvim/.config/nvim/lua/plugins/telescope.lua
+++ b/nvim/.config/nvim/lua/plugins/telescope.lua
@@ -1,0 +1,10 @@
+return { 
+  "nvim-telescope/telescope.nvim", 
+  tag = "0.1.x", 
+  dependencies = { "nvim-lua/plenary.nvim" },
+  config = function()
+    local builtin = require("telescope.builtin")
+    vim.keymap.set("n", "<C-p>", builtin.find_files, {})
+    vim.keymap.set("n", "<leader>fg", builtin.live_grep, {})
+  end    
+}

--- a/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -1,0 +1,13 @@
+return { 
+  "nvim-treesitter/nvim-treesitter", 
+  build = ":TSUpdate",
+  config = function()
+    local config = require("nvim-treesitter.configs")
+    config.setup({
+      ensure_installed = { "lua", "c_sharp", "rust", "go", "css", "html", "javascript", "typescript", "python", "markdown", "markdown_inline" },
+      auto_install = true,
+      highlight = { enable = true },
+      indent = { enable = true }
+    })
+  end
+}

--- a/nvim/.config/nvim/lua/vim-options.lua
+++ b/nvim/.config/nvim/lua/vim-options.lua
@@ -1,0 +1,9 @@
+vim.cmd("set expandtab")
+vim.cmd("set tabstop=2")
+vim.cmd("set softtabstop=2")
+vim.cmd("set shiftwidth=2")
+vim.g.mapleader = " "
+vim.opt.number = true
+vim.opt.relativenumber = true
+vim.opt.signcolumn = "number"
+


### PR DESCRIPTION
## Summary

- **`git/`** — adds `.gitconfig`, includes delta pager configuration
- **`nvim/`** — adds full neovim config: Lazy.nvim, LSP, completions, Telescope, neo-tree, treesitter, lualine, catppuccin, render-markdown, none-ls, lazy-lock.json
- **`beets/`** — adds `config.yaml` with hardcoded `/mnt/ssd/Music` replaced by `$MUSIC_DIR` environment variable

## Notes

All existing real files were removed before stowing so symlinks could be placed cleanly. On a fresh machine `install.sh` will handle this ordering automatically.

`MUSIC_DIR` must be set in the environment before beets is used — will be documented in README (see #15).

Closes #3
Closes #4
Closes #5