### PR TITLE
Expand tmux config with keybindings and UX improvements

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -1,11 +1,99 @@
-# List of plugins
-set -g @plugin 'catppuccin/tmux'
-set -g @plugin 'tmux-plugins/tpm'
-set -g @plugin 'tmux-plugins/tmux-sensible'
-set -g @catppuccin_flavour 'macchiato'
+# =============================================================================
+# General
+# =============================================================================
+
+# Change prefix to C-a (screen-style, easier to reach than C-b)
+unbind C-b
+set -g prefix C-a
+bind C-a send-prefix
+
+# Start windows and panes at 1, not 0
+set -g base-index 1
+setw -g pane-base-index 1
+set -g renumber-windows on
+
+# Increase scrollback buffer
+set -g history-limit 10000
+
+# Reduce escape-time for neovim
+set -sg escape-time 10
+
+# Enable mouse support
+set -g mouse on
+
+# Focus events for neovim autoread
+set -g focus-events on
+
+# =============================================================================
+# Terminal colours
+# =============================================================================
 
 set -g default-terminal "xterm-256color"
 set-option -ga terminal-overrides ",xterm-256color:Tc"
 
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run -b '~/.tmux/plugins/tpm/tpm'
+# =============================================================================
+# Key bindings
+# =============================================================================
+
+# Reload config
+bind r source-file ~/.tmux.conf \; display "Config reloaded"
+
+# Split panes using | and - (and open in current directory)
+unbind '"'
+unbind %
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+
+# New window in current directory
+bind c new-window -c "#{pane_current_path}"
+
+# Vim-style pane navigation
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# Vim-style pane resizing (repeatable)
+bind -r H resize-pane -L 5
+bind -r J resize-pane -D 5
+bind -r K resize-pane -U 5
+bind -r L resize-pane -R 5
+
+# Switch between last two windows
+bind a last-window
+
+# =============================================================================
+# Copy mode (vim keybindings)
+# =============================================================================
+
+setw -g mode-keys vi
+bind Enter copy-mode
+bind -T copy-mode-vi v send -X begin-selection
+bind -T copy-mode-vi y send -X copy-selection-and-cancel
+
+# =============================================================================
+# Status bar (catppuccin)
+# =============================================================================
+
+set -g @catppuccin_flavour 'macchiato'
+set -g @catppuccin_window_left_separator ""
+set -g @catppuccin_window_right_separator " "
+set -g @catppuccin_window_middle_separator " █"
+set -g @catppuccin_window_number_position "right"
+set -g @catppuccin_window_default_fill "number"
+set -g @catppuccin_window_default_text "#W"
+set -g @catppuccin_window_current_fill "number"
+set -g @catppuccin_window_current_text "#W"
+set -g @catppuccin_status_modules_right "session date_time"
+set -g @catppuccin_date_time_text "%H:%M"
+
+# =============================================================================
+# Plugins
+# =============================================================================
+
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'
+set -g @plugin 'catppuccin/tmux'
+
+# Initialize TMUX plugin manager (keep this line at the very bottom)
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

Builds out `.tmux.conf` from bare plugin declarations into a full working config.

**General**
- Prefix changed to `C-a`
- Window/pane numbering starts at 1, auto-renumbers on close
- Mouse support, focus events, increased scrollback, reduced escape-time for neovim

**Keybindings**
- `prefix + |` / `-` — split vertical/horizontal in current directory
- `prefix + h/j/k/l` — vim-style pane navigation
- `prefix + H/J/K/L` — pane resizing (repeatable)
- `prefix + a` — switch to last window
- `prefix + r` — reload config
- `prefix + Enter` — enter copy mode (vi keys, `v` select, `y` yank)

**Status bar**
- Catppuccin Macchiato theme with session name and clock

Closes #8