### PR TITLE
Add tmux session persistence

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -95,5 +95,14 @@ set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'catppuccin/tmux'
 
+# Session persistence — save with prefix + C-s, restore with prefix + C-r
+set -g @plugin 'tmux-plugins/tmux-resurrect'
+set -g @resurrect-capture-pane-contents 'on'
+
+# Auto-save every 15 minutes
+set -g @plugin 'tmux-plugins/tmux-continuum'
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '15'
+
 # Initialize TMUX plugin manager (keep this line at the very bottom)
 run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

Adds two plugins for session persistence:

- **tmux-resurrect** — manual save (`prefix + C-s`) and restore (`prefix + C-r`), with pane contents captured
- **tmux-continuum** — auto-saves every 15 minutes, auto-restores on tmux server start

## Post-merge

Run `prefix + I` in a tmux session to install the new plugins.

Closes #9