### PR TITLE
Add tmux-which-key

### DIFF
--- a/tmux/.config/tmux/plugins/tmux-which-key/config.yaml
+++ b/tmux/.config/tmux/plugins/tmux-which-key/config.yaml
@@ -1,7 +1,10 @@
 command_alias_start_index: 200
 
-# Triggered by prefix + ?
-prefix_table: "?"
+keybindings:
+  prefix_table: "?"
+
+custom_variables: []
+macros: []
 
 title:
   style: align=centre,bold
@@ -32,10 +35,10 @@ items:
       - separator: true
       - name: Split vertical
         key: "|"
-        command: "split-window -h -c '#{pane_current_path}'"
+        command: "split-window -h -c #{pane_current_path}"
       - name: Split horizontal
         key: "-"
-        command: "split-window -v -c '#{pane_current_path}'"
+        command: "split-window -v -c #{pane_current_path}"
       - separator: true
       - name: Zoom toggle
         key: z
@@ -50,7 +53,7 @@ items:
     menu:
       - name: New window
         key: c
-        command: "new-window -c '#{pane_current_path}'"
+        command: "new-window -c #{pane_current_path}"
       - name: Next window
         key: n
         command: next-window
@@ -74,7 +77,7 @@ items:
     menu:
       - name: Sessionizer
         key: f
-        command: "display-popup -E '$HOME/.local/bin/tmux-sessionizer'"
+        command: "display-popup -E $HOME/.local/bin/tmux-sessionizer"
       - name: Choose session
         key: s
         command: choose-tree -Zs
@@ -100,4 +103,4 @@ items:
   # ---- Config ----
   - name: Reload config
     key: r
-    command: "source-file $HOME/.tmux.conf ; display 'Config reloaded'"
+    command: "source-file $HOME/.tmux.conf"

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -100,7 +100,7 @@ set -g @plugin 'catppuccin/tmux'
 
 # Which-key menu — triggered by prefix + ?
 set -g @plugin 'alexwforsythe/tmux-which-key'
-set -g @tmux-which-key-user-config "$HOME/.config/tmux/tmux-which-key.yaml"
+set -g @tmux-which-key-xdg-enable 1
 
 # Session persistence — save with prefix + C-s, restore with prefix + C-r
 set -g @plugin 'tmux-plugins/tmux-resurrect'


### PR DESCRIPTION
## Summary

Adds `alexwforsythe/tmux-which-key` via TPM — shows a grouped popup menu of available bindings when you press `prefix + ?`.

**Menu groups:**
- `p` → +Panes — navigate (h/j/k/l), split (|/-), zoom, kill
- `w` → +Windows — new, next/prev, last, rename, kill
- `s` → +Sessions — sessionizer, choose, rename, detach, save/restore (resurrect)
- `Enter` → copy mode
- `r` → reload config

**Config:** `tmux/.config/tmux/tmux-which-key.yaml` (stowed to `~/.config/tmux/`)

## Post-merge

Run `prefix + I` in a tmux session to install the plugin.

Closes #12