### PR TITLE
Add navi with custom cheatsheets

### DIFF
--- a/cheatsheets/nvim.cheat
+++ b/cheatsheets/nvim.cheat
@@ -1,0 +1,77 @@
+% nvim, modes
+
+; i      insert mode
+; Esc    normal mode
+; v      visual mode
+; V      visual line mode
+; :      command mode
+
+% nvim, navigation
+
+; h/j/k/l   left/down/up/right
+; w/b        next/prev word
+; gg/G       top/bottom of file
+; {/}        prev/next paragraph
+; Ctrl+d/u   half page down/up
+; zz         centre cursor on screen
+
+% nvim, editing
+
+; dd    delete line
+; yy    yank line
+; p     paste after
+; u     undo
+; C-r   redo
+; .     repeat last action
+; ciw   change inner word
+; di"   delete inside quotes
+
+% nvim, search
+
+; /pattern   search forward
+; n/N        next/prev match
+; *          search word under cursor
+; :%s/old/new/g  replace all
+
+% nvim, files
+
+; :w    save
+; :q    quit
+; :wq   save and quit
+; :q!   quit without saving
+
+% nvim, lsp
+
+; K        hover docs
+; gd       go to definition
+; <leader>ca  code action
+
+% nvim, telescope
+
+; Ctrl+p      find files
+; <leader>fg  live grep
+
+% nvim, neo-tree
+
+; Ctrl+n   toggle file tree
+
+% nvim, lazy
+
+# Sync plugins
+:Lazy sync
+
+# Update plugins
+:Lazy update
+
+# Check plugin status
+:Lazy
+
+% nvim, mason
+
+# Open Mason installer
+:Mason
+
+# Install LSP server
+:MasonInstall <server>
+
+$ server: echo -e "lua_ls\nts_ls\nangularls\nomnisharp"

--- a/cheatsheets/shell.cheat
+++ b/cheatsheets/shell.cheat
@@ -1,0 +1,88 @@
+% fzf
+
+; Ctrl+g   fzf-git keybindings
+; Ctrl+t   fuzzy find file and insert path
+; Ctrl+r   fuzzy search shell history
+; Alt+c    fuzzy cd into directory
+
+# Fuzzy find and open in nvim
+nvim $(fzf)
+
+# Fuzzy find with preview
+fzf --preview 'bat --color=always {}'
+
+% git
+
+# Pretty log
+git log --oneline --graph --decorate
+
+# Stage interactively
+git add -p
+
+# Undo last commit (keep changes)
+git reset --soft HEAD~1
+
+# Discard all local changes
+git restore .
+
+# Create and push branch
+git checkout -b <branch> && git push -u origin <branch>
+
+# Delete remote branch
+git push origin --delete <branch>
+
+$ branch: git branch --format '%(refname:short)'
+
+% gh (github cli)
+
+# List open PRs
+gh pr list
+
+# Check out a PR locally
+gh pr checkout <number>
+
+# View PR in browser
+gh pr view <number> --web
+
+# Create issue
+gh issue create --title "<title>" --label "<label>"
+
+# List issues
+gh issue list
+
+$ number: gh pr list --json number --jq '.[].number'
+
+% brew
+
+# Install package
+brew install <package>
+
+# Update all packages
+brew upgrade
+
+# Search for package
+brew search <query>
+
+# Show package info
+brew info <package>
+
+# List installed
+brew list
+
+% shell, utils
+
+# bat — better cat
+bat <file>
+
+# fd — better find
+fd <pattern>
+
+# delta — better git diff (automatic via .gitconfig)
+
+# thefuck — fix last command
+fuck
+
+# tldr — concise man pages
+tldr <command>
+
+$ command: tldr --list 2>/dev/null | fzf

--- a/cheatsheets/tmux.cheat
+++ b/cheatsheets/tmux.cheat
@@ -1,0 +1,64 @@
+% tmux, multiplexer
+
+; Prefix is C-a
+
+# New session
+tmux new -s <name>
+
+# Attach to session
+tmux attach -t <name>
+
+# List sessions
+tmux ls
+
+# Kill server
+tmux kill-server
+
+$ name: tmux ls --format '#{session_name}' --- --column 1
+
+% tmux, panes
+
+; prefix + h/j/k/l to navigate
+; prefix + H/J/K/L to resize
+; prefix + | to split vertical
+; prefix + - to split horizontal
+; prefix + z to zoom/unzoom
+; prefix + x to kill pane
+
+# Split pane vertically (current dir)
+tmux split-window -h -c "#{pane_current_path}"
+
+# Split pane horizontally (current dir)
+tmux split-window -v -c "#{pane_current_path}"
+
+% tmux, windows
+
+; prefix + c  new window
+; prefix + n  next window
+; prefix + p  previous window
+; prefix + a  last window
+; prefix + ,  rename window
+; prefix + &  kill window
+
+# New window in current dir
+tmux new-window -c "#{pane_current_path}"
+
+% tmux, sessions
+
+; prefix + f  sessionizer (fzf project picker)
+; prefix + d  detach
+; prefix + $  rename session
+; prefix + C-s  save (resurrect)
+; prefix + C-r  restore (resurrect)
+
+# Switch to session by name
+tmux switch-client -t <name>
+
+$ name: tmux ls --format '#{session_name}' --- --column 1
+
+% tmux, copy mode
+
+; prefix + Enter  enter copy mode
+; v  begin selection
+; y  yank and exit
+; q  quit copy mode

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -159,3 +159,8 @@ export NVM_DIR="$HOME/.nvm"
 
 # Load Angular CLI autocompletion.
 source <(ng completion script)
+
+# ---- navi (interactive cheatsheets) ----
+
+export NAVI_PATH="$HOME/dotfiles/cheatsheets"
+eval "$(navi widget zsh)"


### PR DESCRIPTION
## Summary

Adds `navi` as an interactive cheatsheet tool with a `Ctrl+G` zsh widget.

**Cheatsheets** (`cheatsheets/` in repo root, travel with dotfiles):
- `tmux.cheat` — sessions, panes, windows, copy mode — uses actual custom bindings
- `nvim.cheat` — motions, LSP keybindings, Telescope, neo-tree, Lazy, Mason
- `shell.cheat` — fzf, git, gh CLI, brew, bat/fd/thefuck/tldr

**Config:** `NAVI_PATH` set in `.zshrc` to point at `~/dotfiles/cheatsheets/`

## Post-merge

Reload shell or run `source ~/.zshrc`. Then press `Ctrl+G` anywhere in the terminal to open the cheatsheet picker.

Closes #13