### PR TITLE
Add tmux popup cheatsheet bindings

### DIFF
--- a/tmux/.config/tmux/plugins/tmux-which-key/config.yaml
+++ b/tmux/.config/tmux/plugins/tmux-which-key/config.yaml
@@ -95,6 +95,20 @@ items:
         key: R
         command: run-shell "~/.tmux/plugins/tmux-resurrect/scripts/restore.sh"
 
+  # ---- Cheatsheets ----
+  - name: +Cheatsheets
+    key: "/"
+    menu:
+      - name: tmux
+        key: t
+        command: "display-popup -E \"less $HOME/dotfiles/cheatsheets/tmux.cheat\""
+      - name: nvim
+        key: n
+        command: "display-popup -E \"less $HOME/dotfiles/cheatsheets/nvim.cheat\""
+      - name: shell
+        key: e
+        command: "display-popup -E \"less $HOME/dotfiles/cheatsheets/shell.cheat\""
+
   # ---- Copy mode ----
   - name: Copy mode
     key: Enter

--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -63,7 +63,12 @@ bind -r L resize-pane -R 5
 bind a last-window
 
 # Sessionizer — fuzzy find project dir and open/switch to its tmux session
-bind f display-popup -E "tmux-sessionizer"
+bind f display-popup -E "$HOME/.local/bin/tmux-sessionizer"
+
+# Cheatsheet popups (q or Esc to close)
+bind C-t display-popup -E "bat --plain $HOME/dotfiles/cheatsheets/tmux.cheat | less -R"
+bind C-n display-popup -E "bat --plain $HOME/dotfiles/cheatsheets/nvim.cheat | less -R"
+bind C-e display-popup -E "bat --plain $HOME/dotfiles/cheatsheets/shell.cheat | less -R"
 
 # =============================================================================
 # Copy mode (vim keybindings)


### PR DESCRIPTION
## Summary

Adds direct `display-popup` bindings for quick cheatsheet access from anywhere in tmux, plus a `+Cheatsheets` submenu in the which-key menu.

**Direct bindings:**
- `prefix + C-t` → tmux cheatsheet
- `prefix + C-n` → nvim cheatsheet
- `prefix + C-e` → shell cheatsheet

**Via which-key** (`prefix + ?` then `/`):
- `t` → tmux, `n` → nvim, `e` → shell

Press `q` or `Esc` to close any popup.

Closes #14