### PR TITLE
Migrate LSP config to native vim.lsp API, replace omnisharp with roslyn

### DIFF
--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -18,5 +18,7 @@
   "nvim-web-devicons": { "branch": "master", "commit": "d7462543c9e366c0d196c7f67a945eaaf5d99414" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "render-markdown.nvim": { "branch": "main", "commit": "e3c18ddd27a853f85a6f513a864cf4f2982b9f26" },
-  "telescope.nvim": { "branch": "master", "commit": "5255aa27c422de944791318024167ad5d40aad20" }
+  "roslyn.nvim": { "branch": "main", "commit": "ff43201090361b8936e008a006473b59ef2c0ca6" },
+  "telescope.nvim": { "branch": "master", "commit": "5255aa27c422de944791318024167ad5d40aad20" },
+  "which-key.nvim": { "branch": "main", "commit": "3aab2147e74890957785941f0c1ad87d0a44c15a" }
 }

--- a/nvim/.config/nvim/lua/plugins/lsp-config.lua
+++ b/nvim/.config/nvim/lua/plugins/lsp-config.lua
@@ -2,36 +2,32 @@ return {
 	{
 		"williamboman/mason.nvim",
 		config = function()
-			require("mason").setup()
+			require("mason").setup({
+				registries = {
+					"github:mason-org/mason-registry",
+					"github:Crashdummyy/mason-registry",
+				},
+			})
 		end,
 	},
 	{
 		"williamboman/mason-lspconfig.nvim",
 		config = function()
 			require("mason-lspconfig").setup({
-				ensure_installed = { "lua_ls", "ts_ls", "angularls", "omnisharp" },
+				ensure_installed = { "lua_ls", "ts_ls", "angularls" },
 			})
 		end,
 	},
 	{
 		"neovim/nvim-lspconfig",
 		config = function()
-			local lspconfig = require("lspconfig")
 			local capabilities = require("cmp_nvim_lsp").default_capabilities()
 
-			lspconfig.lua_ls.setup({
-				capabilities = capabilities,
-			})
-			lspconfig.ts_ls.setup({
-				capabilities = capabilities,
-			})
-			lspconfig.angularls.setup({
-				capabilities = capabilities,
-			})
-			lspconfig.omnisharp.setup({
-				capabilities = capabilities,
-				cmd = { "dotnet", "/usr/bin/omnisharp/OmniSharp.dll" },
-			})
+			vim.lsp.config("lua_ls",    { capabilities = capabilities })
+			vim.lsp.config("ts_ls",     { capabilities = capabilities })
+			vim.lsp.config("angularls", { capabilities = capabilities })
+			vim.lsp.config("roslyn",    { capabilities = capabilities })
+			vim.lsp.enable({ "lua_ls", "ts_ls", "angularls" })
 
 			vim.keymap.set("n", "K", vim.lsp.buf.hover, {})
 			vim.keymap.set("n", "gd", vim.lsp.buf.definition, {})

--- a/nvim/.config/nvim/lua/plugins/roslyn.lua
+++ b/nvim/.config/nvim/lua/plugins/roslyn.lua
@@ -1,0 +1,7 @@
+return {
+	{
+		"seblyng/roslyn.nvim",
+		ft = "cs",
+		opts = {},
+	},
+}


### PR DESCRIPTION
## Summary

- Replaces `lspconfig.*.setup()` calls with `vim.lsp.config()` + `vim.lsp.enable()` (Neovim 0.11 native API)
- Drops omnisharp, adds `seblyng/roslyn.nvim` with the Crashdummyy mason registry
- All four LSPs verified working: `lua_ls`, `ts_ls`, `angularls`, `roslyn`

## Test plan

- [x] `lua_ls` — attached on `.lua` files
- [x] `ts_ls` — attached on `.ts` files
- [x] `angularls` — attached alongside `ts_ls` in Angular projects
- [x] `roslyn` — attached on `.cs` files (requires .NET 10 runtime)

Closes #24