### PR TITLE
Change tmux prefix from C-a to C-b

### DIFF
--- a/tmux/.tmux.conf
+++ b/tmux/.tmux.conf
@@ -2,10 +2,9 @@
 # General
 # =============================================================================
 
-# Change prefix to C-a (screen-style, easier to reach than C-b)
-unbind C-b
-set -g prefix C-a
-bind C-a send-prefix
+unbind C-a
+set -g prefix C-b
+bind C-b send-prefix
 
 # Start windows and panes at 1, not 0
 set -g base-index 1


### PR DESCRIPTION
## Summary

- Reverts tmux prefix to the default `C-b` — `C-a` was set by convention but is physically awkward
- No other files affected (`config.yaml` has no prefix references)

## Test plan

- [x] Reload config with old prefix (`C-a r`), confirm new prefix `C-b` works

Closes #31