### PR TITLE
migrate nvim-treesitter to main branch for Neovim 0.12.0 compatibility

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -18,6 +18,7 @@ brew "tldr"          # concise man pages
 
 # ---- Build tooling ----
 brew "pipx"          # isolated python CLI tool installs
+brew "tree-sitter"   # parser generator, required by nvim-treesitter main branch
 
 # ---- Flatpaks ----
 # GUI apps tracked here for full machine reproducibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,10 +44,6 @@ Tmux plugins managed via TPM at `~/.tmux/plugins/tpm`. Install with `prefix + I`
 
 Neovim plugins managed via Lazy.nvim. Sync with `:Lazy sync` inside nvim.
 
-## Style
-
-- Do not add AI attribution comments or generation notices to any files (no "Generated with Claude Code", "Co-authored by", etc.)
-
 ## Testing install.sh
 
 Use `Dockerfile.test` to validate on a clean Ubuntu 22.04 system:

--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,40 @@ else
 fi
 
 # =============================================================================
-# 4. oh-my-zsh
+# 4. tree-sitter CLI
+# =============================================================================
+#
+# The brew 'tree-sitter' formula installs only the C library, not the CLI
+# binary. nvim-treesitter (main branch) requires the CLI >= 0.26.1 to build
+# parsers. Install the prebuilt binary to ~/.local/bin directly.
+
+info "Checking tree-sitter CLI..."
+
+TREE_SITTER_VERSION="0.26.7"
+TREE_SITTER_BIN="$HOME/.local/bin/tree-sitter"
+
+_install_tree_sitter() {
+    mkdir -p "$HOME/.local/bin"
+    curl -fsSL "https://github.com/tree-sitter/tree-sitter/releases/download/v${TREE_SITTER_VERSION}/tree-sitter-linux-x64.gz" \
+        | gunzip > "$TREE_SITTER_BIN"
+    chmod +x "$TREE_SITTER_BIN"
+    ok "tree-sitter CLI ${TREE_SITTER_VERSION} installed"
+}
+
+if command -v tree-sitter &>/dev/null; then
+    TS_MINOR="$(tree-sitter --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | cut -d. -f2)"
+    if [[ "${TS_MINOR:-0}" -ge 26 ]]; then
+        ok "tree-sitter CLI already installed ($(tree-sitter --version 2>/dev/null))"
+    else
+        info "tree-sitter CLI too old, upgrading to ${TREE_SITTER_VERSION}..."
+        _install_tree_sitter
+    fi
+else
+    _install_tree_sitter
+fi
+
+# =============================================================================
+# 5. oh-my-zsh
 # =============================================================================
 
 info "Checking oh-my-zsh..."
@@ -93,7 +126,7 @@ else
 fi
 
 # =============================================================================
-# 5. Powerlevel10k theme
+# 6. Powerlevel10k theme
 # =============================================================================
 
 info "Checking powerlevel10k..."
@@ -107,7 +140,7 @@ else
 fi
 
 # =============================================================================
-# 6. zsh plugins
+# 7. zsh plugins
 # =============================================================================
 
 info "Checking zsh plugins..."
@@ -131,7 +164,7 @@ else
 fi
 
 # =============================================================================
-# 7. fzf-git.sh
+# 8. fzf-git.sh
 # =============================================================================
 
 info "Checking fzf-git.sh..."
@@ -144,7 +177,7 @@ else
 fi
 
 # =============================================================================
-# 8. TPM (tmux plugin manager)
+# 9. TPM (tmux plugin manager)
 # =============================================================================
 
 info "Checking TPM..."
@@ -157,7 +190,7 @@ else
 fi
 
 # =============================================================================
-# 9. nvm
+# 10. nvm
 # =============================================================================
 
 info "Checking nvm..."
@@ -170,7 +203,7 @@ else
 fi
 
 # =============================================================================
-# 10. COSMIC theme (Catppuccin Macchiato)
+# 11. COSMIC theme (Catppuccin Macchiato)
 # =============================================================================
 
 info "Checking COSMIC theme..."
@@ -190,7 +223,7 @@ else
 fi
 
 # =============================================================================
-# 11. Stow all packages
+# 12. Stow all packages
 # =============================================================================
 
 info "Stowing packages..."
@@ -216,7 +249,7 @@ for pkg in zsh tmux git nvim beets bin; do
 done
 
 # =============================================================================
-# 11. Set default shell to zsh
+# 13. Set default shell to zsh
 # =============================================================================
 
 info "Checking default shell..."
@@ -251,12 +284,12 @@ echo "  2. Log out and back in (or open a new terminal) to get zsh as your shell
 echo ""
 echo "  3. Open tmux and install plugins:"
 echo "       tmux new -s main"
-echo "       # then press: prefix + I  (C-b I)"
+echo "       # then press: prefix + I  (C-a I)"
 echo ""
 echo "  4. Open nvim and sync plugins:"
 echo "       nvim  →  :Lazy sync"
 echo ""
-echo "  6. Import COSMIC Catppuccin theme (if on COSMIC desktop):"
+echo "  5. Import COSMIC Catppuccin theme (if on COSMIC desktop):"
 echo "       COSMIC Settings > Desktop > Appearance > Import"
 echo "         → ~/dotfiles/cosmic/catppuccin-macchiato-mauve+round.ron"
 echo "       COSMIC Terminal > View > Color schemes > Import"

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -15,7 +15,7 @@
   "nui.nvim": { "branch": "main", "commit": "de740991c12411b663994b2860f1a4fd0937c130" },
   "nvim-cmp": { "branch": "main", "commit": "a1d504892f2bc56c2e79b65c6faded2fd21f3eca" },
   "nvim-lspconfig": { "branch": "master", "commit": "16812abf0e8d8175155f26143a8504e8253e92b0" },
-  "nvim-treesitter": { "branch": "master", "commit": "cf12346a3414fa1b06af75c79faebe7f76df080a" },
+  "nvim-treesitter": { "branch": "main", "commit": "7caec274fd19c12b55902a5b795100d21531391f" },
   "nvim-web-devicons": { "branch": "master", "commit": "d7462543c9e366c0d196c7f67a945eaaf5d99414" },
   "plenary.nvim": { "branch": "master", "commit": "b9fd5226c2f76c951fc8ed5923d85e4de065e509" },
   "render-markdown.nvim": { "branch": "main", "commit": "c7188a8f9d2953696b6303caccbf39c51fa2c1b1" },

--- a/nvim/.config/nvim/lua/plugins/treesitter.lua
+++ b/nvim/.config/nvim/lua/plugins/treesitter.lua
@@ -1,13 +1,20 @@
-return { 
-  "nvim-treesitter/nvim-treesitter", 
+return {
+  "nvim-treesitter/nvim-treesitter",
+  branch = "main",
+  lazy = false,
   build = ":TSUpdate",
   config = function()
-    local config = require("nvim-treesitter.configs")
-    config.setup({
-      ensure_installed = { "lua", "c_sharp", "rust", "go", "css", "html", "javascript", "typescript", "python", "markdown", "markdown_inline" },
-      auto_install = true,
-      highlight = { enable = true },
-      indent = { enable = true }
+    require("nvim-treesitter").setup()
+
+    require("nvim-treesitter").install({
+      "lua", "c_sharp", "rust", "go", "css", "html",
+      "javascript", "typescript", "python", "markdown", "markdown_inline"
+    })
+
+    vim.api.nvim_create_autocmd("FileType", {
+      callback = function()
+        pcall(vim.treesitter.start)
+      end,
     })
   end
 }


### PR DESCRIPTION
Closes #42

## Summary

- **nvim-treesitter**: migrate from archived `master` branch to `main` (full rewrite for Neovim 0.12.0+). Rewrites plugin config for the new API — drops `configs.setup()`, replaces `ensure_installed`/`auto_install` with explicit `install()`, enables highlighting via `FileType` autocmd
- **tree-sitter CLI**: add prebuilt binary install to `install.sh` (brew only ships the C library; nvim-treesitter `main` requires the CLI >= 0.26.1 to build parsers)
- **Brewfile**: add `tree-sitter` entry
- **CLAUDE.md**: move cross-project style rule to `~/.claude/CLAUDE.md`, keep only repo-specific content here
- **install.sh**: fix duplicate section 11 numbering, fix post-install step numbering and tmux prefix typo (`C-b` → `C-a`)

## Test plan

- [ ] Fresh bootstrap: `install.sh` installs tree-sitter CLI, nvim opens without treesitter errors
- [ ] Re-run `install.sh` on configured machine: tree-sitter version check skips re-install
- [ ] Syntax highlighting works in nvim across languages in `ensure_installed`